### PR TITLE
Convert to Lua

### DIFF
--- a/nvim/.config/nvim/after/ftplugin/markdown.lua
+++ b/nvim/.config/nvim/after/ftplugin/markdown.lua
@@ -1,7 +1,7 @@
 local opt = vim.opt_local
 
--- convert to lua (above stuff is not working for some reason)
-vim.api.nvim_command('setlocal spell spelllang=en_us,de_de')
+vim.opt_local.spell = true
+vim.opt_local.spelllang = { "en_us", "de_de" }
 
 -- quick fix last wrong word in insert mode
 vim.keymap.set('i', '<C-s>', '<C-g>u<Esc>[s1z=`]a<C-g>u', {desc = 'fix last spelling error'})

--- a/nvim/.config/nvim/after/ftplugin/tex.lua
+++ b/nvim/.config/nvim/after/ftplugin/tex.lua
@@ -2,8 +2,8 @@ local opt = vim.opt_local
 opt.wrap = true
 opt.linebreak = true
 
--- convert to lua (above stuff is not working for some reason)
-vim.api.nvim_command('setlocal spell spelllang=en_us,de_de')
+vim.opt_local.spell = true
+vim.opt_local.spelllang = { "en_us", "de_de" }
 
 -- quick fix last wrong word in insert mode
 vim.keymap.set('i', '<C-s>', '<C-g>u<Esc>[s1z=`]a<C-g>u', {desc = 'fix last spelling error'})

--- a/nvim/.config/nvim/after/ftplugin/text.lua
+++ b/nvim/.config/nvim/after/ftplugin/text.lua
@@ -1,7 +1,7 @@
 local opt = vim.opt_local
 
--- convert to lua (above stuff is not working for some reason)
-vim.api.nvim_command('setlocal spell spelllang=en_us,de_de')
+vim.opt_local.spell = true
+vim.opt_local.spelllang = { "en_us", "de_de" }
 
 -- quick fix last wrong word in insert mode
 vim.keymap.set('i', '<C-s>', '<C-g>u<Esc>[s1z=`]a<C-g>u', {desc = 'fix last spelling error'})


### PR DESCRIPTION
Fixes #1

Convert the configuration to Lua for spell checking in text, markdown, and tex files.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/mokronos/.dotfiles/issues/1?shareId=2c9c27f3-7ad8-4e61-9a48-69c7eaf484a1).